### PR TITLE
'this' context in controller

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.js]
-indent_style = space
+indent_style = tab
 indent_size = 4

--- a/app/modules/app/app.controller.js
+++ b/app/modules/app/app.controller.js
@@ -6,21 +6,20 @@
 		.module('app')
 		.controller('AppController', AppController);
 
-		AppController.$inject = ['$scope'];
+		function AppController() {
 
-		function AppController($scope) {
+			var vm = this;
 
 			// Get current date for footer
-			this.date = new Date();
+			vm.date = new Date();
 
-			this.settings = {
+			vm.settings = {
 				"app": {
-                    "name": "Angular Starter",
-                    "version": "0.1"
-                }
+					"name": "Angular Starter",
+					"version": "0.1"
+				}
 			};
 
 		}
-
 
 })();

--- a/app/modules/view1/view1.controller.js
+++ b/app/modules/view1/view1.controller.js
@@ -6,13 +6,12 @@
 		.module('app.view1')
 		.controller('View1Controller', View1Controller);
 
-		View1Controller.$inject = ['$scope'];
+		function View1Controller() {
 
-		function View1Controller($scope) {
+			var vm = this;
 
-            this.title = "View 1";
+            vm.title = "View 1";
 
 		}
-
 
 })();

--- a/app/modules/view2/view2.controller.js
+++ b/app/modules/view2/view2.controller.js
@@ -6,13 +6,12 @@
 		.module('app.view2')
 		.controller('View2Controller', View2Controller);
 
-		View2Controller.$inject = ['$scope'];
+		function View2Controller() {
 
-		function View2Controller($scope) {
+			var vm = this;
 
-            this.title = "View 2";
+            vm.title = "View 2";
 
 		}
-
 
 })();


### PR DESCRIPTION
based on john papas / todd mottos style guide the context of 'this' is stored in a variable named 'vm' in controllers. 

Also removed '$scope' and the $inject methods as they are not used. Suggestion would be to use [this](https://github.com/Kagami/gulp-ng-annotate) gulp plugin to handle injection of dependencies

resolves #1 

:+1: 
